### PR TITLE
Update setup.py to adapt to $GRADLE_USER_HOME

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,15 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 def unpack_assets():
+    asset_dir = None
+    # get value of $GRADLE_USER_HOME
+    gradle_user_home = os.environ.get('GRADLE_USER_HOME')
+    if gradle_user_home is not None:
+        # $GRADLE_USER_HOME exists:
+        asset_dir = os.path.join(gradle_user_home, 'caches', 'forge_gradle', 'assets')
+    else:
+        # using default path
+        asset_dir = os.path.join(os.path.expanduser('~'), '.gradle', 'caches', 'forge_gradle', 'assets')
     asset_dir = os.path.join(os.path.expanduser('~'), '.gradle', 'caches', 'forge_gradle', 'assets')
     output_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'minerl', 'MCP-Reborn', 'src', 'main', 'resources')
     index = load_asset_index(os.path.join(asset_dir, 'indexes', '1.16.json'))


### PR DESCRIPTION
Adapt to the situation when ".gradle" directory is not under "~" directory (User customized environment variables $GRADLE_USER_HOME)